### PR TITLE
auto-add Custom_Library to path when running Run_Initializer.m

### DIFF
--- a/Template_Files/Run_Initializer.m
+++ b/Template_Files/Run_Initializer.m
@@ -10,6 +10,7 @@
 clear;
 clc;
 close all force;
+addpath(genpath('../../Custom_Library'))
 
 warning('off','all')
 


### PR DESCRIPTION
title says it all. No longer necessary to remember to add the Custom_Library folder to Matlab's path